### PR TITLE
installation: update to reflect current install practices

### DIFF
--- a/audio.md
+++ b/audio.md
@@ -781,31 +781,6 @@ of writing the above to generate a sine through FFmpeg would thus be
 ```{.liquidsoap include="liq/input.ffmpeg.liq" from=1 to=-1}
 ```
 
-#### GStreamer input {#sec:gstreamer-input}
-
-Finally, another very general possibility for input is to use the
-`input.gstreamer.audio` operator in order to use the GStreamer\index{GStreamer}
-library to generate audio. The generation itself is described through a
-_pipeline_ which consists in a sequence of GStreamer operators separated by
-"`!`": a pipeline "`a ! b`" means that the output of operator "`a`" should be
-fed to operator "`b`". We refer the reader to the documentation of the library
-for more information about it. In Liquidsoap, the pipeline can be passed in the
-argument labeled `pipeline`, as expected. For instance, we can generate a sine
-wave (again) with
-
-```{.liquidsoap include="liq/input.gstreamer.liq" from=1 to=-1}
-```
-
-where we use the operator `audiotestsrc` to generate a sine, which we pipe to
-the `audioamplify` operator to change its volume. Similarly, we can play the
-file `test.mp3` with
-
-```{.liquidsoap include="liq/input.gstreamer2.liq" from=1 to=-1}
-```
-
-In practice, no one would use the above example as is, because Liquidsoap
-already has builtin support for using GStreamer to decode files...
-
 #### JACK input
 
 If the other program has support for it, it is possible to use JACK with the
@@ -3845,90 +3820,9 @@ instance,
 ```{.liquidsoap include="liq/encoder-fdkaac.liq" from=2 to=-1}
 ```
 
-### GStreamer
-
-The `%gstreamer` encoder can be used to encode streams using the GStreamer\index{GStreamer}
-multimedia framework, which handles many formats, and can provide effects and
-more on the stream. It is quite useful, although its support in Liquidsoap should
-be considered as much less mature than the FFmpeg encoder, which fulfills
-similar purposes, and is presented next.
-
-The parameters of the `%gstreamer` encoder are
-
-- `channels`: the number of audio channels (2 by default),
-- `log`: the log level of GStreamer between 0 (no message) and 9 (very very
-  verbose), default is 5.
-
-In GStreamer, _pipelines_ describe sequences of GStreamer operators to be
-applied, separated by `!`, see also [there](#sec:gstreamer-input). Those are
-specified by three further parameters of the encoder:
-
-- `audio`: the audio pipeline (default is `"lamemp3enc"`, the LAME mp3 encoder),
-- `video`: the video pipeline (default is `"x264enc"`, the x264 H.264 encoder),
-- `muxer`: the muxer which takes care of encapsulating both audio and video
-  streams (default is `"mpegtsmux"`, which performs MPEG-TS encapsulation).
-
-If the `audio` pipeline is not empty then the number of audio channels specified
-by the `channels` parameter is expected, and if the `video` pipeline is not
-empty then one video channel is expected.
-
-For instance, we can encode a source in mp3 with
-
-```{.liquidsoap include="liq/encoder-gstreamer-1.liq" from=2 to=-1}
-```
-
-The metadata of the encoded is passed to the pipeline element named `"metadata"`
-(the name can be changed with the `metadata` parameter of `%gstreamer`) using
-the "tag setter" API. We can thus encode our stream in mp3 with tags using
-
-```{.liquidsoap include="liq/encoder-gstreamer-2.liq" from=2 to=-1}
-```
-
-or in Vorbis with tags using
-
-```{.liquidsoap include="liq/encoder-gstreamer-3.liq" from=2 to=-1}
-```
-
-Encoding a video in H.264 with mp3 audio encapsulated in MPEG transport stream
-is performed with
-
-```{.liquidsoap include="liq/encoder-gstreamer-4.liq" from=2 to=-1}
-```
-
-and in Ogg/Vorbis+Theora with
-
-```{.liquidsoap include="liq/encoder-gstreamer-5.liq" from=2 to=-1}
-```
-
-The `audio`, `video` and `muxer` are combined internally to form one (big)
-GStreamer pipeline which will handle the whole encoding. For instance, with
-previous example, the generated pipeline is indicated with the following debug
-message:
-
-```
-[encoder.gstreamer:5] GStreamer encoder pipeline: appsrc name="audio_src" block=true caps="audio/x-raw, format=S16LE, layout=interleaved, channels=2, rate=44100" format=time max-bytes=40960 ! queue ! audioconvert ! audioresample ! vorbisenc ! muxer. appsrc name="video_src" block=true caps="video/x-raw, format=I420, width=1280, height=720, framerate=25/1, pixel-aspect-ratio=1/1" format=time blocksize=3686400 max-bytes=40960 ! queue ! videoconvert ! videoscale add-borders=true ! videorate ! theoraenc ! muxer. oggmux name=muxer ! appsink name=sink sync=false emit-signals=true
-```
-
-For advanced users, the `pipeline` argument can be used to directly specify the
-whole pipeline. In this case, the parameter `has_video` is used to determine
-whether the stream has video or not (video is assumed by default). For instance,
-mp3 encoding can also be performed with
-
-```{.liquidsoap include="liq/encoder-gstreamer-pipeline.liq" from=2 to=-1}
-```
-
-Beware that, when using the `%gstreamer` encoder, you should consider that the
-stream you are encoding is infinite (or could be). This means that not all
-containers (and muxers) will work. For instance, the AVI and MP4 containers need
-to write in their header some information that is only known with finite
-streams, such as the total time of the stream. These containers are usually not
-suitable for streaming, which is the main purpose of Liquidsoap.
-
 ### FFmpeg {#sec:ffmpeg-encoder}
 
-The `%ffmpeg`\index{FFmpeg} encoder is a "meta-encoder", just like the GStreamer one: it uses
-the versatile FFmpeg library in order to encode in various formats, including
-the ones presented above, but also many more. The general syntax is
+The `%ffmpeg`\index{FFmpeg} encoder is a versatile meta-encoder that uses the FFmpeg library to encode in a wide variety of formats, including the ones presented above, but also many more. The general syntax is
 
 ```liquidsoap
 %ffmpeg(format="<format>", ...)

--- a/book.md
+++ b/book.md
@@ -23,6 +23,7 @@ header-includes: |
   \usepackage{titlepic}
   \titlepic{\vspace{3cm}\includegraphics[width=3cm]{img/logo.pdf}\vspace{-3cm}}
   \usepackage{perpage}\MakePerPage{footnote}
+  \usepackage{pifont}
   \urlstyle{tt}
 numbersections: true
 secnumdepth: 1

--- a/installation.md
+++ b/installation.md
@@ -144,25 +144,16 @@ below.
 
 #### Updating libraries
 
-If you also need a recent version of the libraries in the Liquidsoap ecosystem,
-you can download all the libraries at once by typing
+If you also need a cutting-edge version of a library in the Liquidsoap ecosystem
+(say, `ocaml-ffmpeg`), you can clone it and pin it directly with opam:
 
 ```
-git clone https://github.com/savonet/liquidsoap-full.git
-cd liquidsoap-full
-make init
-make update
-```
-
-You can then update a given library (say, `ocaml-ffmpeg`) by going in its
-directory and pinning it with opam, e.g.
-
-```
+git clone https://github.com/savonet/ocaml-ffmpeg.git
 cd ocaml-ffmpeg
 opam pin add .
 ```
 
-(and answer yes if you are asked questions).
+Opam will automatically detect the dependency and rebuild Liquidsoap.
 
 Using binaries
 --------------
@@ -187,8 +178,8 @@ features included. You can also inspect a running installation with
 ### Linux
 
 Official packages from the [Liquidsoap release
-page](https://github.com/savonet/liquidsoap/releases) are available for Debian
-and Ubuntu (see the supported releases table in the [versions
+page](https://github.com/savonet/liquidsoap/releases) are available for Debian,
+Ubuntu, and Alpine (see the supported releases table in the [versions
 section](#sec:versions)). When using these packages on Debian, you will also
 need to enable the [deb-multimedia.org](https://www.deb-multimedia.org/)
 repositories, which provide up-to-date libraries including `fdk-aac` support in
@@ -249,12 +240,12 @@ immutable links to release assets, use
 
 ### Supported operating systems for pre-built binaries
 
-| OS      | Supported releases                                         | Architectures       | Notes                                                                              |
-|---------|------------------------------------------------------------|---------------------|------------------------------------------------------------------------------------|
-| Debian  | stable (`trixie`), testing (`forky`)                       | `amd64`, `arm64`    | `.deb` packages require [deb-multimedia.org](https://www.deb-multimedia.org/)      |
-| Ubuntu  | LTS (`resolute`), latest (`plucky`)                        | `amd64`, `arm64`    |                                                                                    |
-| Alpine  | `edge`                                                     | `x86_64`, `aarch64` |                                                                                    |
-| Windows | N/A                                                        | 64-bit              | `.zip` archive                                                                     |
+| OS      | Supported releases                   | Architectures       | Notes                            |
+|---------|--------------------------------------|---------------------|----------------------------------|
+| Debian  | stable (`trixie`), testing (`forky`) | `amd64`, `arm64`    | needs [deb-multimedia.org](https://www.deb-multimedia.org/) repo |
+| Ubuntu  | LTS (`resolute`), latest (`plucky`)  | `amd64`, `arm64`    |                                  |
+| Alpine  | `edge`                               | `x86_64`, `aarch64` |                                  |
+| Windows | N/A                                  | 64-bit              | `.zip` archive                   |
 
 ### Supported FFmpeg versions
 
@@ -320,125 +311,98 @@ device located at `/dev/snd`, in which case passing the additional option
 Libraries used by Liquidsoap
 ----------------------------
 
-We list below some of the libraries which can be used by Liquidsoap. They are
-detected during the compilation of Liquidsoap and, in this case, support for the
-libraries is added. We recall that a library `ocaml-something` can be installed
-via opam with
+All names below refer to **opam package names** — install any of them with
+`opam install <name>` and Liquidsoap will be automatically rebuilt with the
+corresponding feature enabled. The full list of what is compiled into a
+particular binary can be queried with `liquidsoap --build-config`.
 
-```
-opam install something
-```
-
-which will automatically trigger a rebuild of Liquidsoap, as explained in [the
-above section](#sec:opam).
+Some libraries are always required and compiled in automatically: `camomile`
+(metadata charset recoding), `curl` (HTTP downloads), `metadata` (tag reading),
+`mem_usage` (memory reporting), and `magic-mime` (file-type detection by
+content). The libraries listed below are all optional.
 
 ### General
 
-Those libraries add support for various things:
-
-- `camomile`: charset recoding in metadata (those are generally encoded in UTF-8
-  which can represent all characters, but older files used various encodings for
-  characters which can be converted),
-- `ocaml-inotify`: getting notified when a file changes (e.g. for reloading a
-  playlist when it has been updated),
-- `ocaml-magic`: file type detection (e.g. this is useful for detecting that a
-  file is an MP3 even if it does not have the `.mp3` extension),
-- `ocaml-lo`: OSC (Open Sound Control) support for controlling the radio
-  (changing the volume, switching between sources) via external interfaces
-  (e.g. an application on your phone),
-- `ocaml-ssl`: SSL support for connecting to secured websites (using the https
-  protocol),
-- `ocaml-tls`: similar to `ocaml-ssl`,
-- `ocurl`: downloading files over http,
-- `osx-secure-transport`: SSL support via OSX's SecureTransport,
-- `yojson`: parsing JSON data (useful to exchange data with other applications).
+- `inotify`: filesystem watch — reload playlists automatically when a file
+  changes (Linux only; macOS uses a native equivalent),
+- `lo`: OSC (Open Sound Control) support via liblo, for controlling Liquidsoap
+  from phone apps or hardware controllers,
+- `osc-unix`: pure-OCaml OSC alternative to `lo`,
+- `ssl`: SSL/TLS support for `https://` connections,
+- `tls-liquidsoap`: pure-OCaml TLS alternative to `ssl`,
+- `irc-client-unix`: IRC chat output,
+- `sqlite3`: SQLite database support (useful for playlist logging and history),
+- `yaml`: YAML data parsing.
 
 ### Input / output
 
-Those libraries add support for using soundcards for playing and recording sound:
+Soundcard input and output:
 
-- `ocaml-alsa`: soundcard input and output with ALSA,
-- `ocaml-ao`: soundcard output using AO,
-- `ocaml-ffmpeg`: input and output over various devices,
-- `ocaml-gstreamer`: input and output over various devices,
-- `ocaml-portaudio`: soundcard input and output,
-- `ocaml-pulseaudio`: soundcard input and output.
+- `alsa`: ALSA — the low-level Linux soundcard interface, lowest latency,
+- `ao`: AO — a cross-platform output-only library,
+- `portaudio`: PortAudio — cross-platform input and output,
+- `pulseaudio`: PulseAudio — the standard Linux audio server.
 
-Among those, pulseaudio is a safe default bet. ALSA is very low level and is
-probably the one you want to use in order to minimize latencies. Other libraries
-support a wider variety of soundcards and usages.
+Network and device I/O:
 
-Other outputs:
+- `ffmpeg`: input and output via FFmpeg (files, network streams, devices),
+- `bjack`: JACK support for low-latency interconnection between audio programs,
+- `srt`: transport over the network using the SRT protocol.
 
-- `ocaml-cry`: output to icecast servers,
-- `ocaml-bjack`: Jack support for virtually connecting audio programs,
-- `ocaml-lastfm`: Last.fm scrobbling (this website basically records the songs
-  you have listened),
-- `ocaml-srt`: transport over network using SRT protocol.
+Icecast/Shoutcast streaming output is always compiled in (via the `cry`
+library, which is a required dependency).
 
 ### Sound processing
 
-Those add support for sound manipulation:
-
-- `ocaml-dssi`: sound synthesis plugins,
-- `ocaml-ladspa`: sound effect plugins,
-- `ocaml-lilv`: sound effect plugins,
-- `ocaml-samplerate`: samplerate conversion in audio files,
-- `ocaml-soundtouch`: pitch shifting and time stretching.
+- `dssi`: DSSI sound synthesis plugins,
+- `ladspa`: LADSPA audio effect plugins,
+- `lilv`: LV2 audio plugin support via Lilv,
+- `samplerate`: high-quality sample rate conversion,
+- `soundtouch`: pitch shifting and time stretching.
 
 ### Audio file formats
 
-- `ocaml-faad`: AAC decoding,
-- `ocaml-fdkaac`: AAC+ encoding,
-- `ocaml-ffmpeg`: encoding and decoding of various formats,
-- `ocaml-flac`: Flac encoding and decoding,
-- `ocaml-gstreamer`: encoding and decoding of various formats,
-- `ocaml-lame`: MP3 encoding,
-- `ocaml-mad`: MP3 decoding,
-- `ocaml-ogg`: Ogg containers,
-- `ocaml-opus`: Ogg/Opus encoding and decoding,
-- `ocaml-shine`: fixed-point MP3 encoding,
-- `ocaml-speex`: Ogg/Speex encoding and decoding,
-- `ocaml-taglib`: metadata decoding,
-- `ocaml-vorbis`: Ogg/Vorbis encoding and decoding.
-
-### Playlists
-
-- `ocaml-xmlplaylist`: support for playlist formats based on XML.
+- `faad`: AAC decoding,
+- `fdkaac`: AAC-LC/HE-AAC encoding via the Fraunhofer FDK library,
+- `ffmpeg`: encoding and decoding of all FFmpeg-supported formats,
+- `flac`: native FLAC encoding and decoding,
+- `lame`: MP3 encoding via LAME,
+- `mad`: MP3 decoding via MAD,
+- `ogg`: Ogg container support,
+- `opus`: Ogg/Opus encoding and decoding,
+- `shine`: fixed-point MP3 encoding (useful on low-power devices),
+- `speex`: Ogg/Speex encoding and decoding,
+- `vorbis`: Ogg/Vorbis encoding and decoding.
 
 ### Video
 
-Video conversion:
-
-- `ocaml-ffmpeg`: video conversion,
-- `ocaml-gavl`: video conversion,
-- `ocaml-theora`: Ogg/Theora encoding and decoding.
-
-Other video-related libraries:
-
-- `camlimages`: decoding of various image formats,
-- `gd4o`: rendering of text,
-- `ocaml-frei0r`: video effects,
-- `ocaml-imagelib`: decoding of various image formats,
-- `ocaml-sdl`: display, text rendering and image formats.
+- `ffmpeg`: video decoding, encoding, scaling and filtering,
+- `theora`: Ogg/Theora video encoding and decoding,
+- `camlimages`: decoding of common image formats (JPEG, PNG, GIF, …),
+- `frei0r`: frei0r video effect plugins,
+- `gd`: text and image rendering via the GD library,
+- `graphics`: simple display via the OCaml Graphics library,
+- `sdl-liquidsoap`: SDL2 display, font rendering, and image loading (meta-package
+  that pulls the correct versions of `tsdl`, `tsdl-ttf`, and `tsdl-image`).
 
 ### Memory
 
-Memory usage is sometimes an issue with some scripts:
+- `jemalloc`: jemalloc allocator — reduces memory fragmentation on long-running
+  scripts,
+- `memtrace`: memory allocation tracing for diagnosing leaks.
 
-- `ocaml-jemalloc`: support for jemalloc memory allocator which can avoid memory
-  fragmentation and lower the memory footprint,
-- `ocaml-memtrace`: support for tracing memory allocation in order to understand
-  where memory consumption comes from,
-- `ocaml-mem_usage`: detailed memory usage information.
+### Monitoring
+
+- `prometheus-liquidsoap`: exposes Liquidsoap metrics (sources, outputs, buffer
+  levels, etc.) as a Prometheus endpoint for scraping by monitoring systems.
 
 ### Runtime dependencies
 
-Those optional dependencies can be used by Liquidsoap if installed, they are
-detected at runtime and do not require any particular support during
-compilation:
+These are used by Liquidsoap at runtime if present on the system; they do not
+affect compilation:
 
-- `awscli`: `s3://` and `polly://` protocol support for Amazon web servers,
-- `curl`: downloading files with `http`, `https` and `ftp` protocols,
-- `ffmpeg`: external input and output, `replay_gain`, level computation, and more,
-- `youtube-dl`: YouTube video and playlist downloading support.
+- `ffmpeg` CLI: used by some operators for external processing (e.g. ReplayGain
+  analysis),
+- `awscli`: enables the `s3://` and `polly://` protocols for Amazon Web Services,
+- `yt-dlp` (or `youtube-dl`): enables downloading from YouTube and other
+  video platforms via the `youtube://` protocol.

--- a/installation.md
+++ b/installation.md
@@ -12,7 +12,7 @@ Automated building using opam {#sec:opam}
 -----------------------------
 
 The recommended method to install Liquidsoap is by using the [package manager
-opam](http://opam.ocaml.org/)\index{opam}. This program, which is available on all major
+opam](https://opam.ocaml.org/)\index{opam}. This program, which is available on all major
 distributions and architectures, makes it easy to build programs written in
 OCaml by installing the required dependencies (the libraries the program needs
 to be compiled) and managing consistency between various versions (in
@@ -24,23 +24,17 @@ libraries are actively maintained.
 
 ### Installing opam
 
-The easiest way to install opam on any achitecture is by running the command
-
-```
-sh <(curl -sL https://git.io/fjMth)
-```
-
-or by installing the `opam` package with the package manager of your
-distribution, e.g., for Ubuntu,
+The easiest way to install opam is by following the instructions on the [opam
+install page](https://opam.ocaml.org/doc/Install.html), or by installing the
+`opam` package with the package manager of your distribution, e.g., for
+Ubuntu,
 
 ```
 sudo apt install opam
 ```
 
-or by downloading the binaries from [the opam
-website](http://opam.ocaml.org/doc/Install.html). In any case, you should ensure
-that you have at least the version 2.0.0 of opam: the version number can be
-checked by running `opam --version`.
+In any case, you should ensure that you have at least version **2.1** of opam:
+the version number can be checked by running `opam --version`.
 
 If you are installing opam for the first time, you should initialize the list of
 opam packages with
@@ -51,11 +45,18 @@ opam init
 
 You can answer yes to all the questions it asks (if it complains about the
 absence of `bwrap`, either install it or add the flag `--disable-sandboxing` to
-the above command line). Next thing, you should install a recent version of the
-OCaml compiler by running
+the above command line). Next, you should install a supported version of the
+OCaml compiler. Not all versions are supported; you can run
 
 ```
-opam switch create 4.13.0
+opam info liquidsoap-lang
+```
+
+to find out which OCaml versions are compatible. Then create a switch for your
+chosen version:
+
+```
+opam switch create <ocaml version>
 ```
 
 It does take a few minutes, because it compiles OCaml, so get prepared to have a
@@ -63,42 +64,47 @@ coffee.
 
 ### Installing Liquidsoap
 
-Once this is done, a typical installation of Liquidsoap with support for mp3
-encoding/decoding and Icecast is done by executing:
+Once this is done, a typical installation of Liquidsoap with most expected
+features is done by executing:
 
 ```
-opam depext  taglib mad lame cry samplerate liquidsoap
-opam install taglib mad lame cry samplerate liquidsoap
+opam install ffmpeg liquidsoap
 ```
 
-The first line (`opam depext ...`) takes care of installing the required
-external dependencies, i.e., the libraries we are relying on, but did not
-develop by ourselves. Here, we want to install the dependencies required by
-`taglib` (the library to read tags in audio files), `mad` (to decode mp3),
-`lame` (to encode mp3), `cry` (to stream to Icecast), `samplerate` (to resample
-audio) and finally `liquidsoap`. The second line (`opam install ...`) actually
-install the libraries and programs. Here also, the compilation takes some time
-(around a minute on a recent computer).
+This installs `liquidsoap` along with the optional `ffmpeg` package, which
+provides most of the expected functionalities (encoding, decoding, metadata
+support, etc.) out of the box. Starting with opam 2.1, external dependencies
+(system libraries) are handled automatically — opam will ask for your permission
+to install them or guide you through the process.
 
 Most of Liquidsoap's dependencies are only optionally installed by opam. For
-instance, if you want to enable ogg/vorbis encoding and decoding after you've already
-installed Liquidsoap, you should install the `vorbis` library by executing:
+instance, if you want to enable ogg/vorbis encoding and decoding after you've
+already installed Liquidsoap, you should install the `vorbis` library by
+executing:
 
 ```
-opam depext  vorbis
 opam install vorbis
 ```
 
 Opam will automatically detect that this library can be used by Liquidsoap and
-will recompile it which will result in adding support for this format in
-Liquidsoap. The list of all optional dependencies that you may enable in
-Liquidsoap can be obtained by typing
+will recompile it, resulting in added support for this format. The list of all
+optional dependencies that you may enable in Liquidsoap can be obtained by
+typing
 
 ```
 opam info liquidsoap
 ```
 
 and is detailed below.
+
+**Note for macOS users**: when using [Homebrew](https://brew.sh/), you may need
+to add the following to your shell configuration so that opam can find the
+installed libraries:
+
+```
+export CPATH=/opt/homebrew/include
+export LIBRARY_PATH=/opt/homebrew/lib
+```
 
 ### Installing the cutting-edge version
 
@@ -132,6 +138,10 @@ git pull
 opam upgrade liquidsoap
 ```
 
+As an alternative to pinning from source, rolling release binaries are available
+for upcoming versions — see [the section on versions and releases](#sec:versions)
+below.
+
 #### Updating libraries
 
 If you also need a recent version of the libraries in the Liquidsoap ecosystem,
@@ -161,129 +171,133 @@ If you want to avoid compiling Liquidsoap, or if opam is not working on your
 platform, the easiest way is to use precompiled binaries of Liquidsoap, if
 available.
 
+Binary packages and docker images are provided in two flavors:
+
+- The main `liquidsoap` packages are compiled with all available features and
+  functions. This is a good starting point for general-purpose development.
+- Packages and images labelled `-minimal` are compiled without extra libraries
+  and with a limited set of essential optional features. These are recommended
+  for production if they meet your needs, as they reduce size, memory usage, and
+  the chance of issues from unused optional dependencies.
+
+Each binary build comes with a corresponding `*.config` file listing all
+features included. You can also inspect a running installation with
+`liquidsoap --build-config`.
+
 ### Linux
 
-There are packages for Liquidsoap in most Linux distributions. For instance, in
-Ubuntu or Debian, the installation can be performed by running
+Official packages from the [Liquidsoap release
+page](https://github.com/savonet/liquidsoap/releases) are available for Debian
+and Ubuntu (see the supported releases table in the [versions
+section](#sec:versions)). When using these packages on Debian, you will also
+need to enable the [deb-multimedia.org](https://www.deb-multimedia.org/)
+repositories, which provide up-to-date libraries including `fdk-aac` support in
+FFmpeg.
 
-```
-sudo apt install liquidsoap
-```
-
-which will install the `liquidsoap` package, containing the main binaries. It
-comes equipped with most essential features, but you can install plugins in the
-packages `liquidsoap-plugin-...` to have access to more libraries; for instance,
-installing `liquidsoap-plugin-flac` will add support for the flac lossless audio
-format or `liquidsoap-plugin-all` will install all available plugins (which
-might be a good idea if you are not sure about which you are going to need).
+Your distribution may also carry its own `liquidsoap` package (e.g. via
+`sudo apt install liquidsoap`), though these may lag behind the latest release.
 
 ### macOS
 
-No binaries are provided for macOS, the preferred method is opam, see above.
+No pre-built binaries are provided for macOS. The preferred installation method
+is opam, as described above.
 
 ### Windows
 
 Pre-built binaries are provided on the [releases
-pages](https://github.com/savonet/liquidsoap/releases) in a file with a name of
+page](https://github.com/savonet/liquidsoap/releases) in a file with a name of
 the form `liquidsoap-vN.N.N-win64.zip`. It contains directly the program, no
 installer is provided at the moment.
+
+Versions and releases {#sec:versions}
+---------------------
+
+### Semantic versioning
+
+Liquidsoap releases follow semantic versioning:
+
+```
+<major_version>.<minor_version>.<bugfix_version>
+```
+
+- `major_version` is bumped for major changes (paradigm shifts, major
+  implementation changes). Versions with different major numbers **are**
+  incompatible.
+- `minor_version` is bumped for minor changes (new operators, renames, new
+  modules). Versions with different minor numbers **may be** incompatible.
+- `bugfix_version` is bumped for bugfix releases. Only-bugfix-version changes
+  **should be** compatible.
+
+We strongly recommend maintaining a staging environment to test new versions
+before deploying them in production.
+
+### Current release status
+
+| Branch  | Latest release | Supported | Rolling Release         |
+|---------|----------------|-----------|-------------------------|
+| `2.5.x` | 🚧 (in dev)   | 🚧        | `main` branch           |
+| `2.4.x` | 2.4.2          | ✅        | `rolling-release-v2.4.x` |
+| `2.3.x` | 2.3.3          | ❌        | —                       |
+
+### Rolling releases
+
+A rolling release is a snapshot of a current, unpublished release — it may
+become the next stable or bugfix release for a given major/minor version. Rolling
+release assets may be updated, added, or removed at any time. For permanent,
+immutable links to release assets, use
+[liquidsoap-release-assets](https://github.com/savonet/liquidsoap-release-assets/releases).
+
+### Supported operating systems for pre-built binaries
+
+| OS      | Supported releases                                         | Architectures       | Notes                                                                              |
+|---------|------------------------------------------------------------|---------------------|------------------------------------------------------------------------------------|
+| Debian  | stable (`trixie`), testing (`forky`)                       | `amd64`, `arm64`    | `.deb` packages require [deb-multimedia.org](https://www.deb-multimedia.org/)      |
+| Ubuntu  | LTS (`resolute`), latest (`plucky`)                        | `amd64`, `arm64`    |                                                                                    |
+| Alpine  | `edge`                                                     | `x86_64`, `aarch64` |                                                                                    |
+| Windows | N/A                                                        | 64-bit              | `.zip` archive                                                                     |
+
+### Supported FFmpeg versions
+
+Liquidsoap supports the last two major releases of FFmpeg. Currently, this means
+versions **7** and **8**.
 
 Building from source
 --------------------
 
-In some cases, it is necessary to build directly from source (e.g., if opam is
-not supported on your exotic architecture or if you want to modify the source
-code of Liquidsoap). This can be a difficult task, because Liquidsoap relies on
-an up-to-date version of the OCaml compiler, as well as a bunch of OCaml
-libraries and, for most of them, corresponding C library dependencies.
+Building Liquidsoap from source is intended for developers who need to modify
+the code or work on platforms not covered by the available binaries or opam.
+It requires an up-to-date OCaml compiler and a number of OCaml libraries and
+their C library dependencies.
 
-### Installing external dependencies
-
-In order to build Liquidsoap, you first need to install the following OCaml
-libraries: `ocamlfind`, `sedlex`, `menhir`, `pcre` and `camomile`. You can
-install those using your package manager
-
-```
-sudo apt install ocaml-findlib libsedlex-ocaml-dev menhir libpcre-ocaml-dev libcamomile-ocaml-dev
-```
-
-(as you can remark, OCaml packages for Debian or Ubuntu often bear names of the
-form `libxxx-ocaml-dev`), or using opam
-
-```
-opam install ocamlfind sedlex menhir pcre camomile
-```
-
-or from source.
-
-### Getting the sources of Liquidsoap
-
-The sources of Liquidsoap, along with the required additional OCaml libraries we
-maintain can be obtained by downloading the main git repository, and then run
-scripts which will download the submodules corresponding to the various
-libraries:
-
-```
-git clone https://github.com/savonet/liquidsoap-full.git
-cd liquidsoap-full
-make init
-make update
-```
-
-<!--
-Alternatively, they bundled in the [`liquidsoap-<version>-full.tar.bz2` archive
-on the release page](https://github.com/savonet/liquidsoap/releases).
--->
-
-### Installing
-
-Next, you should copy the file `PACKAGES.default` to `PACKAGES` and possibly
-edit it: this file specifies which features and libraries are going to be
-compiled, you can add/remove those by uncommenting/commenting the corresponding
-lines. Then, you can generate the `configure` scripts:
-
-```
-./bootstrap
-```
-
-and then run them:
-
-```
-./configure
-```
-
-This script will check that whether the required external libraries are
-available, and detect the associated parameters. It optionally takes parameters
-such as `--prefix` which can be used to specify in which directory the
-installation should be performed. You can now build everything
-
-```
-make
-```
-
-and then proceed to the installation
-
-```
-make install
-```
-
-You may need to be root to run the above command in order to have the right to
-install in the usual directories for libraries and binaries.
+For detailed and up-to-date build instructions, please refer to the [online
+build documentation](https://www.liquidsoap.info/doc-dev/build.html).
 
 Docker image
 ------------
 
-[Docker](https://www.docker.com/)\index{Docker} images are provided as `savonet/liquidsoap`:
-these are Debian-based images with Liquidsoap pre-installed (and not much more
-in order to have a file as small as possible), which you can use to easily and
-securely deploy scripts using it. The tag `main` always contains the latest
-version, and is automatically generated after each modification.
+[Docker](https://www.docker.com/)\index{Docker} images are provided as `savonet/liquidsoap`
+on [Docker Hub](https://hub.docker.com/r/savonet/liquidsoap). These are
+Debian-based images with Liquidsoap pre-installed (kept minimal for size), which
+you can use to easily and securely deploy scripts.
+
+Images are tagged with:
+
+- a release version (e.g. `v2.4.2`) — note these may be updated,
+- a git commit SHA (e.g. `a24bf49`) — these are permanent,
+- a rolling-release tag (e.g. `rolling-release-v2.4.x`) — tracks the latest
+  snapshot for that branch.
+
+For example, to pull release `2.4.2`:
+
+```
+docker pull savonet/liquidsoap:v2.4.2
+```
 
 We refer the reader to the Docker documentation for the way such images can be
 used. For instance, you can have a shell on such an image with
 
 ```
-docker run -it --entrypoint /bin/bash savonet/liquidsoap:main
+docker run -it --entrypoint /bin/bash savonet/liquidsoap:v2.4.2
 ```
 
 By default, the docker image does not have access to the soundcard of the local
@@ -293,7 +307,7 @@ computer inside the image. For instance, you can play a sine (see
 [there](#sec:sound-sine)) by running:
 
 ```
-docker run -it -v /dev/snd:/dev/snd --privileged savonet/liquidsoap:main liquidsoap 'output.alsa(sine())'
+docker run -it -v /dev/snd:/dev/snd --privileged savonet/liquidsoap:v2.4.2 liquidsoap 'output.alsa(sine())'
 ```
 
 This single line should work on any computer on which Docker is installed: no
@@ -312,8 +326,7 @@ libraries is added. We recall that a library `ocaml-something` can be installed
 via opam with
 
 ```
-sudo opam depext  something
-sudo opam install something
+opam install something
 ```
 
 which will automatically trigger a rebuild of Liquidsoap, as explained in [the
@@ -377,7 +390,7 @@ Those add support for sound manipulation:
 
 - `ocaml-faad`: AAC decoding,
 - `ocaml-fdkaac`: AAC+ encoding,
-- `ocaml-ffmepg`: encoding and decoding of various formats,
+- `ocaml-ffmpeg`: encoding and decoding of various formats,
 - `ocaml-flac`: Flac encoding and decoding,
 - `ocaml-gstreamer`: encoding and decoding of various formats,
 - `ocaml-lame`: MP3 encoding,

--- a/installation.md
+++ b/installation.md
@@ -235,9 +235,9 @@ before deploying them in production.
 
 | Branch  | Latest release | Supported | Rolling Release         |
 |---------|----------------|-----------|-------------------------|
-| `2.5.x` | 🚧 (in dev)   | 🚧        | `main` branch           |
-| `2.4.x` | 2.4.2          | ✅        | `rolling-release-v2.4.x` |
-| `2.3.x` | 2.3.3          | ❌        | —                       |
+| `2.5.x` | (in dev)       | (dev)     | `main` branch           |
+| `2.4.x` | 2.4.2          | \ding{51} | `rolling-release-v2.4.x` |
+| `2.3.x` | 2.3.3          | \ding{55} | —                       |
 
 ### Rolling releases
 

--- a/video.md
+++ b/video.md
@@ -414,9 +414,8 @@ not found the silver bullet yet. Those implementations are
 - `video.add_text.native`: the native implementation. It always works and does
   not rely on any external library, but uses a hand-made, hard-coded, low-fi
   font.
-- `video.add_text.sdl` / `video.add_text.gd` / `video.add_text.gstreamer` /
-  `video.add_text.ffmpeg`: synthesize the text using SDL, GD, GStreamer and
-  FFmpeg libraries.
+- `video.add_text.sdl` / `video.add_text.gd` / `video.add_text.ffmpeg`:
+  synthesize the text using SDL, GD, or FFmpeg libraries.
   
 For instance,
 


### PR DESCRIPTION
## Summary

- Fix dead opam installer URL, bump minimum opam version requirement to 2.1
- Replace hardcoded OCaml switch version with `opam info liquidsoap-lang` guidance
- Replace old `opam depext` + multi-package install with `opam install ffmpeg liquidsoap`
- Add macOS Homebrew environment variable note for opam builds
- Enhance binary builds section: explain full vs `-minimal` flavors, `*.config` / `--build-config`
- Update Debian section: add deb-multimedia.org requirement, remove outdated plugin-package install
- Update Docker section with versioned tag (`v2.4.2`), commit-SHA, and rolling-release tag examples
- New section "Versions and releases": semantic versioning semantics, current release/support table, rolling releases explanation, supported OS table, supported FFmpeg versions (7 and 8)
- Simplify "Building from source" to point to the online build docs (the old `liquidsoap-full` / `bootstrap` / `configure` workflow no longer reflects upstream reality)

## Test plan

- [x] CI build passes
- [x] Review rendered PDF for table formatting